### PR TITLE
Increase default password length to comply password policy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -610,7 +610,7 @@ commands:
         admin_username: admin
         admin_firstname: John
         admin_lastname: Doe
-        admin_password: password123
+        admin_password: passwordpassword123
         admin_frontname: admin
         admin_email: john.doe@example.com
         encryption_key:


### PR DESCRIPTION
Avoid new Magento policy fail
- Password must include both numeric and alphabetic characters.
- Password must be at least of 14 characters.